### PR TITLE
Fix grep expression

### DIFF
--- a/get_hadoop_version.sh
+++ b/get_hadoop_version.sh
@@ -2,4 +2,4 @@
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-grep 'ARG HADOOP_VERSION' ${SCRIPT_DIR}/Dockerfile | cut -d '=' -f 2
+grep -E '^ARG HADOOP_VERSION' ${SCRIPT_DIR}/Dockerfile | cut -d '=' -f 2


### PR DESCRIPTION
find only the line starting with `ARG`